### PR TITLE
allow users to provide relative path in planckton flow root directory

### DIFF
--- a/src/project.py
+++ b/src/project.py
@@ -81,17 +81,16 @@ def sampled(job):
     return current_step(job) >= job.doc.steps
 
 
-def get_paths(key):
+def get_paths(key, job):
     from planckton.compounds import COMPOUND
     try:
         return COMPOUND[key]
     except KeyError:
-        # this will be the path to the job e.g.,
+        # job.ws will be the path to the job e.g.,
         # path/to/planckton-flow/workspace/jobid
-        dir_path = path.dirname(path.realpath(__file__))
         # this is the planckton root dir e.g.,
         # path/to/planckton-flow
-        file_path = path.abspath(path.join(dir_path, "..", "..", "..", key))
+        file_path = path.abspath(path.join(job.ws, "..", "..", key))
         if path.isfile(key):
             print(f"Using {key} for structure")
             return key
@@ -127,7 +126,7 @@ def sample(job):
 
 
     with job:
-        inputs = [get_paths(i) for i in job.sp.input]
+        inputs = [get_paths(i,job) for i in job.sp.input]
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
             compound = [Compound(i) for i in inputs]

--- a/src/project.py
+++ b/src/project.py
@@ -101,7 +101,7 @@ def get_paths(key):
         raise FileNotFoundError(
             "Please provide either a path to a file (the absolute path or the "
             "relative path in the planckton-flow root directory) or a key to "
-            f"the COMOUND dictionary: {COMPOUND.keys()}\n"
+            f"the COMPOUND dictionary: {COMPOUND.keys()}\n"
             f"You provided: {key}"
         )
 

--- a/src/project.py
+++ b/src/project.py
@@ -9,6 +9,7 @@ import flow
 from flow import FlowProject, directives
 from flow.environment import DefaultSlurmEnvironment
 from flow.environments.xsede import Bridges2Environment, CometEnvironment
+from os import path
 
 
 class MyProject(FlowProject):
@@ -85,7 +86,24 @@ def get_paths(key):
     try:
         return COMPOUND[key]
     except KeyError:
-        return key
+        # this will be the path to the job e.g.,
+        # path/to/planckton-flow/workspace/jobid
+        dir_path = path.dirname(path.realpath(__file__))
+        # this is the planckton root dir e.g.,
+        # path/to/planckton-flow
+        file_path = path.abspath(path.join(dir_path, "..", "..", "..", key))
+        if path.isfile(key):
+            print(f"Using {key} for structure")
+            return key
+        elif path.isfile(file_path):
+            print(f"Using {file_path} for structure")
+            return file_path
+        raise FileNotFoundError(
+            "Please provide either a path to a file (the absolute path or the "
+            "relative path in the planckton-flow root directory) or a key to "
+            f"the COMOUND dictionary: {COMPOUND.keys()}\n"
+            f"You provided: {key}"
+        )
 
 def on_container(func):
         return flow.directives(

--- a/test_local.py
+++ b/test_local.py
@@ -25,8 +25,7 @@ def test():
     init.main(test_params)
     workspace = signac.get_project()
     for job in workspace:
-        pass
-    project.sample(job)
+        project.sample(job)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
fixes https://github.com/cmelab/planckton/issues/49

- provided path can be absolute path or relative path from planckton-flow root directory
- More descriptive error message