### PR TITLE
Fix n_compounds for mixtures

### DIFF
--- a/src/init.py
+++ b/src/init.py
@@ -35,7 +35,7 @@ parameters = {
 
     # If a mixture is used, the number of each compound in the mixture
     # needs to be specified:
-    # "n_compounds" = [(100,100), (1000,500)]
+    # "n_compounds" = [[100,100], [1000,500]]
     # Even if not doing a mixture, enter n_compounds as a list or tuple (Example: [[100]]
     # Value for n_compounds must be an integer, not a float. (Example: Use 2 instead of 2.0)
     "n_compounds": [[100]],

--- a/src/init.py
+++ b/src/init.py
@@ -36,8 +36,9 @@ parameters = {
     # If a mixture is used, the number of each compound in the mixture
     # needs to be specified:
     # "n_compounds" = [(100,100), (1000,500)]
+    # Even if not doing a mixture, enter n_compounds as a list or tuple (Example: [[100]]
     # Value for n_compounds must be an integer, not a float. (Example: Use 2 instead of 2.0)
-    "n_compounds": [100],
+    "n_compounds": [[100]],
 
     # Density specified as a string, like "value_unit" replacing "/" with "-"
     "density": ["1.0_g-cm**3"],

--- a/src/project.py
+++ b/src/project.py
@@ -135,7 +135,7 @@ def sample(job):
             packer = Pack(
                 compound,
                 ff=FORCEFIELD[job.sp.forcefield],
-                n_compounds=job.sp.n_compounds,
+                n_compounds=list(job.sp.n_compounds),
                 density=units.string_to_quantity(job.sp.density),
                 remove_hydrogen_atoms=job.sp.remove_hydrogens,
             )


### PR DESCRIPTION
This should fix #22. The signac statepoint for `n_compounds` is converted to a list when being passed into the packing function.