### PR TITLE
Use job doc to manage "sampled" label

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,6 @@ name: planckton-flow
 channels:
   - conda-forge
 dependencies:
-  - gsd=2.4.2
   - pip=20.2
   - pytest
   - python=3.7

--- a/src/project.py
+++ b/src/project.py
@@ -157,8 +157,7 @@ def sample(job):
         )
 
 
-        my_sim.run()
-        job.doc["done"] = True
+        job.doc["done"] = my_sim.run()
 
         ref_distance = my_sim.ref_values.distance * u.Angstrom
         ref_energy = my_sim.ref_values.energy * u.kcal / u.mol

--- a/src/project.py
+++ b/src/project.py
@@ -71,18 +71,9 @@ class Kestrel(DefaultSlurmEnvironment):
 
 
 # Definition of project-related labels (classification)
-def current_step(job):
-    import gsd.hoomd
-
-    if job.isfile("trajectory.gsd"):
-        with gsd.hoomd.open(job.fn("trajectory.gsd")) as traj:
-            return traj[-1].configuration.step
-    return -1
-
-
 @MyProject.label
 def sampled(job):
-    return current_step(job) >= job.doc.steps
+    return job.doc.get("done")
 
 
 def get_paths(key, job):
@@ -167,6 +158,7 @@ def sample(job):
 
 
         my_sim.run()
+        job.doc["done"] = True
 
         ref_distance = my_sim.ref_values.distance * u.Angstrom
         ref_energy = my_sim.ref_values.energy * u.kcal / u.mol


### PR DESCRIPTION
Before we were opening each gsd file to check that it had the correct number of steps, which was slow in large workspaces.

fixes #24 